### PR TITLE
Remove redundant local rules and replace references to the equivalent…

### DIFF
--- a/2.0 Sylvan Elves.cat
+++ b/2.0 Sylvan Elves.cat
@@ -47,25 +47,25 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="a40a-c010-ccbb-9793" hidden="false" targetId="defb-3df1-9c6c-4e1e" type="rule">
+        <infoLink id="a40a-c010-ccbb-9793" hidden="false" targetId="f805-0cc6-79ad-644f" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="0cdb-a9e3-f790-13af" hidden="false" targetId="6c0b-3f13-524c-1737" type="rule">
+        <infoLink id="0cdb-a9e3-f790-13af" hidden="false" targetId="65d6-5a10-6cc7-588c" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="a2cd-8b21-36e8-e7f0" hidden="false" targetId="13eb-7241-d8bb-7140" type="rule">
+        <infoLink id="a2cd-8b21-36e8-e7f0" hidden="false" targetId="0537-a0aa-e705-1c3f" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="8c16-60a3-bd5f-7ea1" hidden="false" targetId="f877-7c70-71da-b29f" type="rule">
+        <infoLink id="8c16-60a3-bd5f-7ea1" hidden="false" targetId="ab39-a600-7518-3c98" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -142,31 +142,31 @@ Dance of Disarming Delusions: Enemy units in base contact with the model cannot 
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="73fe-584e-6d53-2151" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="73fe-584e-6d53-2151" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="eed9-c95d-03fe-f6b6" hidden="false" targetId="f404-5e25-ddfa-a222" type="rule">
+        <infoLink id="eed9-c95d-03fe-f6b6" hidden="false" targetId="2511-4948-7f34-a968" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="97f7-c667-f56a-549e" hidden="false" targetId="eb6e-0176-89d0-d671" type="rule">
+        <infoLink id="97f7-c667-f56a-549e" hidden="false" targetId="8519-f096-bc6c-5a20" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="dbdd-48b0-6b2f-da86" hidden="false" targetId="bf92-a7ca-3ba4-9552" type="rule">
+        <infoLink id="dbdd-48b0-6b2f-da86" hidden="false" targetId="538c-9aaf-b9e6-c49e" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="ddea-d21c-40a7-1131" hidden="false" targetId="d970-41c1-7931-dd2c" type="rule">
+        <infoLink id="ddea-d21c-40a7-1131" hidden="false" targetId="5798-4176-b70b-7067" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -178,7 +178,7 @@ Dance of Disarming Delusions: Enemy units in base contact with the model cannot 
             </modifier>
           </modifiers>
         </infoLink>
-        <infoLink id="6617-80ca-163b-8d62" hidden="false" targetId="f6da-4ff4-72af-f5b2" type="rule">
+        <infoLink id="6617-80ca-163b-8d62" hidden="false" targetId="eef2-1c8e-53fc-e1e7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -190,7 +190,7 @@ Dance of Disarming Delusions: Enemy units in base contact with the model cannot 
             </modifier>
           </modifiers>
         </infoLink>
-        <infoLink id="dddb-9fb4-4e30-b048" hidden="false" targetId="fbc9-6558-a0ab-3ae6" type="rule">
+        <infoLink id="dddb-9fb4-4e30-b048" hidden="false" targetId="f346-7788-6db3-4f54" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -337,7 +337,7 @@ Dance of Disarming Delusions: Enemy units in base contact with the model cannot 
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="32cc-1ba4-4b51-ad0f" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="32cc-1ba4-4b51-ad0f" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -349,13 +349,13 @@ Dance of Disarming Delusions: Enemy units in base contact with the model cannot 
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="6df6-c3e7-d537-5697" hidden="false" targetId="f404-5e25-ddfa-a222" type="rule">
+        <infoLink id="6df6-c3e7-d537-5697" hidden="false" targetId="2511-4948-7f34-a968" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="076c-a4d4-fe1f-3492" hidden="false" targetId="d970-41c1-7931-dd2c" type="rule">
+        <infoLink id="076c-a4d4-fe1f-3492" hidden="false" targetId="5798-4176-b70b-7067" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -367,7 +367,7 @@ Dance of Disarming Delusions: Enemy units in base contact with the model cannot 
             </modifier>
           </modifiers>
         </infoLink>
-        <infoLink id="e72f-54b7-dff6-4f58" hidden="false" targetId="257e-4d91-0df6-fb41" type="rule">
+        <infoLink id="e72f-54b7-dff6-4f58" hidden="false" targetId="71cc-bb5b-f7de-89ed" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -455,7 +455,7 @@ Dance of Disarming Delusions: Enemy units in base contact with the model cannot 
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="5845-6345-73fb-8a8a" hidden="false" targetId="dfe4-4598-cdcb-3d58" type="rule">
+                <infoLink id="5845-6345-73fb-8a8a" hidden="false" targetId="eac1-7f72-303a-29a1" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -561,7 +561,7 @@ Dance of Disarming Delusions: Enemy units in base contact with the model cannot 
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="b94e-12eb-1a06-bb24" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="b94e-12eb-1a06-bb24" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -911,13 +911,13 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and a Ward Save (5+). The 
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="e895-76fa-1836-1330" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="e895-76fa-1836-1330" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="85a8-0707-f590-4647" hidden="false" targetId="59c7-5de5-9ed9-4a85" type="rule">
+        <infoLink id="85a8-0707-f590-4647" hidden="false" targetId="8ffe-301a-d8e2-9dcc" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1305,7 +1305,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and a Ward Save (5+). The 
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="7610-67f7-8f54-653b" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="7610-67f7-8f54-653b" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1561,13 +1561,13 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and a Ward Save (5+). The 
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="614a-689c-4354-49c4" hidden="false" targetId="defb-3df1-9c6c-4e1e" type="rule">
+        <infoLink id="614a-689c-4354-49c4" hidden="false" targetId="f805-0cc6-79ad-644f" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="f63f-d342-09a0-e7cb" hidden="false" targetId="0413-de6f-f6b3-99e0" type="rule">
+        <infoLink id="f63f-d342-09a0-e7cb" hidden="false" targetId="a7ae-ba34-84c0-bcb7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1763,7 +1763,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and a Ward Save (5+). The 
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="5262-41a6-b60d-fc72" hidden="false" targetId="defb-3df1-9c6c-4e1e" type="rule">
+        <infoLink id="5262-41a6-b60d-fc72" hidden="false" targetId="f805-0cc6-79ad-644f" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1846,7 +1846,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and a Ward Save (5+). The 
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="73e4-108c-8dc1-0789" hidden="false" targetId="9f78-9e64-5f78-9116" type="rule">
+                <infoLink id="73e4-108c-8dc1-0789" hidden="false" targetId="6215-ee19-c0cf-6201" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -1877,7 +1877,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and a Ward Save (5+). The 
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="e3a7-3733-5eb8-40f5" hidden="false" targetId="fbc9-6558-a0ab-3ae6" type="rule">
+                <infoLink id="e3a7-3733-5eb8-40f5" name="s" hidden="false" targetId="f346-7788-6db3-4f54" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -1909,17 +1909,29 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and a Ward Save (5+). The 
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="4630-14b0-6fe7-8dd9" hidden="false" targetId="0603-04a0-1dae-2c25" type="rule">
+        <infoLink id="4630-14b0-6fe7-8dd9" name="" hidden="false" targetId="31e2-1a5f-05ef-78fb" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="name" value="Strider (Forest)">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
-        <infoLink id="7a95-e192-8cce-11f9" hidden="false" targetId="0424-9d00-5cf6-1c3b" type="rule">
+        <infoLink id="7a95-e192-8cce-11f9" hidden="false" targetId="9650-17c8-3d02-371c" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="name" value="Fly (9)">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
       </infoLinks>
       <modifiers/>
@@ -1990,13 +2002,13 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and a Ward Save (5+). The 
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="9988-e791-a689-9d5e" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="9988-e791-a689-9d5e" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="33be-bc2c-dc25-1119" hidden="false" targetId="fbc9-6558-a0ab-3ae6" type="rule">
+        <infoLink id="33be-bc2c-dc25-1119" hidden="false" targetId="f346-7788-6db3-4f54" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2230,7 +2242,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and a Ward Save (5+). The 
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="a41e-1dfd-a952-ea6e" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="a41e-1dfd-a952-ea6e" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2586,13 +2598,13 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="6e5a-33ae-105f-d69e" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="6e5a-33ae-105f-d69e" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="02c1-6d4a-d71a-0b9a" hidden="false" targetId="59c7-5de5-9ed9-4a85" type="rule">
+        <infoLink id="02c1-6d4a-d71a-0b9a" hidden="false" targetId="8ffe-301a-d8e2-9dcc" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2914,13 +2926,13 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="4e1a-66c4-e05d-98f5" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="4e1a-66c4-e05d-98f5" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="d164-f40d-1c3d-a2b6" hidden="false" targetId="ab5a-ba3e-e350-f395" type="rule">
+        <infoLink id="d164-f40d-1c3d-a2b6" hidden="false" targetId="285f-1256-b70b-7ecb" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2932,13 +2944,13 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
             </modifier>
           </modifiers>
         </infoLink>
-        <infoLink id="3f21-a2a4-833d-9043" hidden="false" targetId="bf92-a7ca-3ba4-9552" type="rule">
+        <infoLink id="3f21-a2a4-833d-9043" hidden="false" targetId="538c-9aaf-b9e6-c49e" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="3687-eed4-4c0e-5b87" hidden="false" targetId="fbc9-6558-a0ab-3ae6" type="rule">
+        <infoLink id="3687-eed4-4c0e-5b87" hidden="false" targetId="f346-7788-6db3-4f54" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2955,6 +2967,18 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <rules/>
           <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="6b96-5b16-e258-22a4" name="New InfoLink" hidden="false" targetId="3b7c-3961-69c1-c1a0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="name" value="Armour Piercing (1)">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
       </infoLinks>
       <modifiers/>
@@ -3090,7 +3114,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="da1f-2e62-521d-33ab" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="da1f-2e62-521d-33ab" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3108,11 +3132,17 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="48bb-d90f-d067-1460" hidden="false" targetId="0603-04a0-1dae-2c25" type="rule">
+        <infoLink id="48bb-d90f-d067-1460" hidden="false" targetId="31e2-1a5f-05ef-78fb" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="name" value="Strider (Forest)">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
       </infoLinks>
       <modifiers/>
@@ -3187,7 +3217,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="1bf1-b6fb-fc9c-cfdc" hidden="false" targetId="9b50-d626-f736-425c" type="rule">
+            <infoLink id="1bf1-b6fb-fc9c-cfdc" hidden="false" targetId="a288-e5e7-00cd-9968" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3243,7 +3273,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="1abb-da3c-d110-8e5d" hidden="false" targetId="fbc9-6558-a0ab-3ae6" type="rule">
+                <infoLink id="1abb-da3c-d110-8e5d" hidden="false" targetId="f346-7788-6db3-4f54" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -3271,7 +3301,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="3102-4ae8-0141-9681" hidden="false" targetId="f262-31af-7436-6b4d" type="rule">
+                <infoLink id="3102-4ae8-0141-9681" hidden="false" targetId="ce5c-09ba-20b2-667b" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -3371,7 +3401,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="29f7-15c3-1a93-8979" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="29f7-15c3-1a93-8979" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3389,25 +3419,31 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="a85c-4bc9-c53a-2727" hidden="false" targetId="f262-31af-7436-6b4d" type="rule">
+        <infoLink id="a85c-4bc9-c53a-2727" hidden="false" targetId="ce5c-09ba-20b2-667b" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="331e-cb72-fa33-218d" hidden="false" targetId="54ee-3450-34ff-fd56" type="rule">
+        <infoLink id="331e-cb72-fa33-218d" hidden="false" targetId="a3de-a61f-be77-6869" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="c1cd-c187-eee5-b69f" hidden="false" targetId="0424-9d00-5cf6-1c3b" type="rule">
+        <infoLink id="c1cd-c187-eee5-b69f" hidden="false" targetId="9650-17c8-3d02-371c" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="name" value="Fly (9)">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
-        <infoLink id="5be7-6a65-f092-3be7" hidden="false" targetId="b83d-0950-72e0-9e47" type="rule">
+        <infoLink id="5be7-6a65-f092-3be7" hidden="false" targetId="3b7c-3961-69c1-c1a0" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3419,7 +3455,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
             </modifier>
           </modifiers>
         </infoLink>
-        <infoLink id="b50a-76f4-20dd-a78c" hidden="false" targetId="9f78-9e64-5f78-9116" type="rule">
+        <infoLink id="b50a-76f4-20dd-a78c" hidden="false" targetId="6215-ee19-c0cf-6201" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3658,7 +3694,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="4a7a-2f08-7ab8-67f2" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="4a7a-2f08-7ab8-67f2" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4082,7 +4118,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="7d3a-1cba-4ae2-f688" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="7d3a-1cba-4ae2-f688" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4443,7 +4479,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="9f65-260e-9388-9d70" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="9f65-260e-9388-9d70" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4832,13 +4868,13 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="51de-9b8f-4a63-ad0c" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="51de-9b8f-4a63-ad0c" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="7ed0-3af9-fff6-2646" hidden="false" targetId="9f78-9e64-5f78-9116" type="rule">
+        <infoLink id="7ed0-3af9-fff6-2646" hidden="false" targetId="6215-ee19-c0cf-6201" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4850,7 +4886,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="cad2-7269-f288-a9a1" hidden="false" targetId="5d00-a3cf-3558-9c90" type="rule">
+        <infoLink id="cad2-7269-f288-a9a1" hidden="false" targetId="2164-ceb1-2c7a-5175" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4940,13 +4976,13 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="51d9-9b0f-b426-51ac" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="51d9-9b0f-b426-51ac" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="44d0-0530-75bd-bbf6" hidden="false" targetId="fbc9-6558-a0ab-3ae6" type="rule">
+        <infoLink id="44d0-0530-75bd-bbf6" hidden="false" targetId="f346-7788-6db3-4f54" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4962,7 +4998,13 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="append" field="name" value="(Black Arrows)">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
       </infoLinks>
       <modifiers/>
@@ -5108,13 +5150,13 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="e6de-83be-0f87-3c9f" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="e6de-83be-0f87-3c9f" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="9480-ecbc-d09a-b7b5" hidden="false" targetId="9f78-9e64-5f78-9116" type="rule">
+        <infoLink id="9480-ecbc-d09a-b7b5" hidden="false" targetId="6215-ee19-c0cf-6201" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5193,7 +5235,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="0dce-9a7c-3a4e-d8f7" hidden="false" targetId="5d00-a3cf-3558-9c90" type="rule">
+            <infoLink id="0dce-9a7c-3a4e-d8f7" hidden="false" targetId="2164-ceb1-2c7a-5175" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -5273,36 +5315,36 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="e725-cd52-5bb4-f67f" hidden="false" targetId="defb-3df1-9c6c-4e1e" type="rule">
+        <infoLink id="e725-cd52-5bb4-f67f" hidden="false" targetId="f805-0cc6-79ad-644f" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="0d9d-4ef5-ac1e-39f0" hidden="false" targetId="6c0b-3f13-524c-1737" type="rule">
+        <infoLink id="0d9d-4ef5-ac1e-39f0" hidden="false" targetId="65d6-5a10-6cc7-588c" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="8c91-0266-70a8-6bc0" hidden="false" targetId="b83d-0950-72e0-9e47" type="rule">
+        <infoLink id="8c91-0266-70a8-6bc0" hidden="false" targetId="285f-1256-b70b-7ecb" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="name" value="Armour Piercing (1)">
+            <modifier type="set" field="name" value="Bodyguard (Thicket Shepherd)">
               <repeats/>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
         </infoLink>
-        <infoLink id="6537-4b44-a9ab-23b1" hidden="false" targetId="ab5a-ba3e-e350-f395" type="rule">
+        <infoLink id="6537-4b44-a9ab-23b1" hidden="false" targetId="3b7c-3961-69c1-c1a0" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="name" value="Bodyguard (Thicket Shepherd)">
+            <modifier type="set" field="name" value="Armour Piercing (1)">
               <repeats/>
               <conditions/>
               <conditionGroups/>
@@ -5315,7 +5357,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="644e-e54d-b215-8aaf" name="New InfoLink" hidden="false" targetId="fbc9-6558-a0ab-3ae6" type="rule">
+        <infoLink id="644e-e54d-b215-8aaf" name="New InfoLink" hidden="false" targetId="f346-7788-6db3-4f54" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5469,19 +5511,19 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="4a65-c084-a18a-da6a" hidden="false" targetId="defb-3df1-9c6c-4e1e" type="rule">
+        <infoLink id="4a65-c084-a18a-da6a" hidden="false" targetId="f805-0cc6-79ad-644f" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="041e-0482-c228-14d2" hidden="false" targetId="6c0b-3f13-524c-1737" type="rule">
+        <infoLink id="041e-0482-c228-14d2" hidden="false" targetId="65d6-5a10-6cc7-588c" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="3c87-fd02-891f-20ea" hidden="false" targetId="b83d-0950-72e0-9e47" type="rule">
+        <infoLink id="3c87-fd02-891f-20ea" hidden="false" targetId="3b7c-3961-69c1-c1a0" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5572,25 +5614,25 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="0a9d-523c-7648-6ea3" hidden="false" targetId="defb-3df1-9c6c-4e1e" type="rule">
+        <infoLink id="0a9d-523c-7648-6ea3" hidden="false" targetId="f805-0cc6-79ad-644f" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="4917-d024-3fe6-baf4" hidden="false" targetId="6c0b-3f13-524c-1737" type="rule">
+        <infoLink id="4917-d024-3fe6-baf4" hidden="false" targetId="65d6-5a10-6cc7-588c" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="5738-0324-f005-bfe6" hidden="false" targetId="13eb-7241-d8bb-7140" type="rule">
+        <infoLink id="5738-0324-f005-bfe6" hidden="false" targetId="0537-a0aa-e705-1c3f" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="5e8e-0cb6-8e69-34f1" hidden="false" targetId="f877-7c70-71da-b29f" type="rule">
+        <infoLink id="5e8e-0cb6-8e69-34f1" hidden="false" targetId="ab39-a600-7518-3c98" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5660,25 +5702,25 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="82c6-a64e-d623-9261" hidden="false" targetId="defb-3df1-9c6c-4e1e" type="rule">
+        <infoLink id="82c6-a64e-d623-9261" hidden="false" targetId="f805-0cc6-79ad-644f" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="1703-a2e2-bb13-b0fb" hidden="false" targetId="6c0b-3f13-524c-1737" type="rule">
+        <infoLink id="1703-a2e2-bb13-b0fb" hidden="false" targetId="65d6-5a10-6cc7-588c" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="3b5b-1afe-b1a8-c596" hidden="false" targetId="13eb-7241-d8bb-7140" type="rule">
+        <infoLink id="3b5b-1afe-b1a8-c596" hidden="false" targetId="0537-a0aa-e705-1c3f" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="19d8-e23a-a0ae-2c00" hidden="false" targetId="f877-7c70-71da-b29f" type="rule">
+        <infoLink id="19d8-e23a-a0ae-2c00" hidden="false" targetId="ab39-a600-7518-3c98" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5917,7 +5959,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="0422-3395-4b13-c81d" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="0422-3395-4b13-c81d" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5935,25 +5977,25 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="88cc-1a8e-61ff-353d" hidden="false" targetId="f404-5e25-ddfa-a222" type="rule">
+        <infoLink id="88cc-1a8e-61ff-353d" hidden="false" targetId="2511-4948-7f34-a968" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="22f0-80de-b2c5-edbe" hidden="false" targetId="351b-4312-9e18-53e8" type="rule">
+        <infoLink id="22f0-80de-b2c5-edbe" hidden="false" targetId="bdf9-9f2e-d42d-377b" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="9d3a-afbb-6291-c213" hidden="false" targetId="54ee-3450-34ff-fd56" type="rule">
+        <infoLink id="9d3a-afbb-6291-c213" hidden="false" targetId="a3de-a61f-be77-6869" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="dc32-2ba3-844a-ebcf" hidden="false" targetId="d970-41c1-7931-dd2c" type="rule">
+        <infoLink id="dc32-2ba3-844a-ebcf" hidden="false" targetId="5798-4176-b70b-7067" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6203,7 +6245,7 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and +1 to its Ward Save (M
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="68dc-00f3-2e03-6d3a" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="68dc-00f3-2e03-6d3a" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6293,7 +6335,7 @@ The model gains +1 Ballistic Skill, Scout, Master Archers and Multiple Shots (4)
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="c526-aeb9-d1d3-0a33" hidden="false" targetId="5d00-a3cf-3558-9c90" type="rule">
+            <infoLink id="c526-aeb9-d1d3-0a33" hidden="false" targetId="2164-ceb1-2c7a-5175" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6305,7 +6347,7 @@ The model gains +1 Ballistic Skill, Scout, Master Archers and Multiple Shots (4)
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="adca-eac6-d0ff-b876" hidden="false" targetId="cc69-c792-df5a-0ffa" type="rule">
+            <infoLink id="adca-eac6-d0ff-b876" hidden="false" targetId="ca8e-9417-40fc-d8f4" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6588,7 +6630,7 @@ The model gains +1 Ballistic Skill, Scout, Master Archers and Multiple Shots (4)
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="2a60-4e70-7393-60e7" hidden="false" targetId="6dca-0ce0-13f6-b428" type="rule">
+        <infoLink id="2a60-4e70-7393-60e7" hidden="false" targetId="91a8-78da-5211-3ae7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6655,7 +6697,7 @@ The model gains +1 Ballistic Skill, Scout, Master Archers and Multiple Shots (4)
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="5e78-2202-1b48-4bc5" hidden="false" targetId="5d00-a3cf-3558-9c90" type="rule">
+            <infoLink id="5e78-2202-1b48-4bc5" hidden="false" targetId="2164-ceb1-2c7a-5175" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6667,7 +6709,7 @@ The model gains +1 Ballistic Skill, Scout, Master Archers and Multiple Shots (4)
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="335a-d811-4cbe-ee4b" hidden="false" targetId="cc69-c792-df5a-0ffa" type="rule">
+            <infoLink id="335a-d811-4cbe-ee4b" hidden="false" targetId="ca8e-9417-40fc-d8f4" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -7046,19 +7088,31 @@ The model gains +1 Ballistic Skill, Scout, Master Archers and Multiple Shots (4)
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="9c48-b7db-6c5c-eba7" hidden="false" targetId="0424-9d00-5cf6-1c3b" type="rule">
+        <infoLink id="9c48-b7db-6c5c-eba7" hidden="false" targetId="9650-17c8-3d02-371c" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="name" value="Fly (7)">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
-        <infoLink id="cb31-6dc2-9061-be1f" hidden="false" targetId="0603-04a0-1dae-2c25" type="rule">
+        <infoLink id="cb31-6dc2-9061-be1f" hidden="false" targetId="31e2-1a5f-05ef-78fb" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="name" value="Strider (Forest)">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
-        <infoLink id="ad28-1002-c19d-98ff" hidden="false" targetId="9acb-baeb-7606-3a9e" type="rule">
+        <infoLink id="ad28-1002-c19d-98ff" hidden="false" targetId="a2f8-8f3b-b414-2ab5" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7117,19 +7171,31 @@ The model gains +1 Ballistic Skill, Scout, Master Archers and Multiple Shots (4)
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="af3b-c9ed-6b53-ef76" hidden="false" targetId="0424-9d00-5cf6-1c3b" type="rule">
+        <infoLink id="af3b-c9ed-6b53-ef76" hidden="false" targetId="9650-17c8-3d02-371c" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="name" value="Fly (7)">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
-        <infoLink id="f786-0a83-184a-a5f7" hidden="false" targetId="0603-04a0-1dae-2c25" type="rule">
+        <infoLink id="f786-0a83-184a-a5f7" hidden="false" targetId="31e2-1a5f-05ef-78fb" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="name" value="Strider (Forest)">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
-        <infoLink id="04d7-6a20-44d6-786b" hidden="false" targetId="9acb-baeb-7606-3a9e" type="rule">
+        <infoLink id="04d7-6a20-44d6-786b" hidden="false" targetId="a2f8-8f3b-b414-2ab5" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7188,11 +7254,17 @@ The model gains +1 Ballistic Skill, Scout, Master Archers and Multiple Shots (4)
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="d3d1-c776-7e09-7489" hidden="false" targetId="0603-04a0-1dae-2c25" type="rule">
+        <infoLink id="d3d1-c776-7e09-7489" hidden="false" targetId="31e2-1a5f-05ef-78fb" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="name" value="Strider (Forest)">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
       </infoLinks>
       <modifiers/>
@@ -7257,17 +7329,29 @@ The model gains +1 Ballistic Skill, Scout, Master Archers and Multiple Shots (4)
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="409b-39b9-7228-0e11" hidden="false" targetId="0424-9d00-5cf6-1c3b" type="rule">
+        <infoLink id="409b-39b9-7228-0e11" hidden="false" targetId="9650-17c8-3d02-371c" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="name" value="Fly (9)">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
-        <infoLink id="2ceb-8d3b-98f7-64c0" hidden="false" targetId="0603-04a0-1dae-2c25" type="rule">
+        <infoLink id="2ceb-8d3b-98f7-64c0" hidden="false" targetId="31e2-1a5f-05ef-78fb" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="name" value="Strider (Forest)">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
       </infoLinks>
       <modifiers/>
@@ -7316,11 +7400,17 @@ The model gains +1 Ballistic Skill, Scout, Master Archers and Multiple Shots (4)
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="ae1b-91b2-df89-e766" hidden="false" targetId="0603-04a0-1dae-2c25" type="rule">
+        <infoLink id="ae1b-91b2-df89-e766" hidden="false" targetId="31e2-1a5f-05ef-78fb" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="name" value="Strider (Forest)">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
       </infoLinks>
       <modifiers/>
@@ -7393,25 +7483,31 @@ The model gains Movement 9 , +2 Initiative, +1 Attack and a Ward Save (5+). The 
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="18a1-3f8e-bda2-9ab0" hidden="false" targetId="0603-04a0-1dae-2c25" type="rule">
+        <infoLink id="18a1-3f8e-bda2-9ab0" hidden="false" targetId="31e2-1a5f-05ef-78fb" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="name" value="Strider (Forest)">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4008-dd6d-900d-b098" hidden="false" targetId="e309-e68b-5b0a-3912" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="4008-dd6d-900d-b098" hidden="false" targetId="c202-c60b-9af6-6124" type="rule">
+        <infoLink id="4b3f-0344-19c2-83c1" hidden="false" targetId="adaa-9e77-3b12-f481" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="4b3f-0344-19c2-83c1" hidden="false" targetId="9963-0573-a9aa-83d7" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="8d2c-2c61-ee0e-9355" hidden="false" targetId="f6da-4ff4-72af-f5b2" type="rule">
+        <infoLink id="8d2c-2c61-ee0e-9355" hidden="false" targetId="eef2-1c8e-53fc-e1e7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7899,13 +7995,13 @@ has successfully charged into combat.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="9d60-2aa1-83c3-355b" hidden="false" targetId="54ee-3450-34ff-fd56" type="rule">
+            <infoLink id="9d60-2aa1-83c3-355b" hidden="false" targetId="a3de-a61f-be77-6869" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="6009-8e86-224a-d9b5" hidden="false" targetId="351b-4312-9e18-53e8" type="rule">
+            <infoLink id="6009-8e86-224a-d9b5" hidden="false" targetId="bdf9-9f2e-d42d-377b" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9837,212 +9933,12 @@ has successfully charged into combat.</description>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
-    <rule id="a213-08a9-8470-11e0" name="Accurate" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Shooting Weapons with this special rule or Shooting Attacks from model parts with this special rule don&apos;t suffer the -1 penalty for Shooting at Long Range .</description>
-    </rule>
-    <rule id="9b50-d626-f736-425c" name="Ambush" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Before Deployment, after choosing Deployment Zones, an army that includes units with the Ambush special rule must state which of your units with this special rule will use it (starting with the player that picked the Deployment Zone).
-Deploy your army as usual, but without deploying any of the Ambushing units. Starting from Game Turn 2, roll a dice for each Ambushing unit at the start of each of your Remaining Moves subphases. After you have rolled for all Ambushing units, each unit that rolled 3+, now enters the Battlefield from any table edge. Place the arriving unit with all of its back rank touching the Board Edge. Ambushing models are free to move in the Remaining Moves subphase, except that they may not March Move, and they must end this Movement Phase no more than twice their Movement value from the Board Edge. If an Ambushing unit has not entered the board (due to failing all its 3+ rolls) before the game ends, the unit counts as destroyed. An Ambushing Character may choose to be deployed within an Ambushing unit that it would normally be allowed to join (declare this when declaring which units are Ambushing). In that case the player rolls once for the combined unit. Until arriving on the Battlefield, Ambushing units cannot do any actions at all, and all items, rules, abilities etc. do not work while not on the Battlefield.</description>
-    </rule>
-    <rule id="f669-461f-4883-eb51" name="Apex Predator" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>When charging a ​single model with Towering Presence ​or a single model with the Fly special rule, the Apex Predator ​gains a +2” modifier​ to its Charge Range. </description>
-    </rule>
-    <rule id="8492-1ca8-f645-0a0b" name="Area Attack" page="88" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>When an attack with this special rule hits a unit, chose up to X different ranks of this unit, the ranks resulting in the maximum amount of hits. For each rank selected this way: the unit suffers X hits, to a maximum equal to the number of models in this rank.
-Some Area Attacks have a higher Strength and/or additional special rules stated in square brackets (such as
-Strength 3[7], [Multiple Wounds (D3)]). If so, a single hit from this attack uses the Strength value and special rules in brackets. The Bracketed values and special rules are not applied to any other hits.</description>
-    </rule>
-    <rule id="b83d-0950-72e0-9e47" name="Armour Piercing (X)" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Attacks made with this special rule and Close Combat Attacks made by parts of models with this special rule impose a X penalty on the enemy’s Armour Saves taken against them (in addition to the normal modifier from the Strength of the
-attack). If an attack has more than one instance of the Armour Piercing special rule, use the highest value available for the attack.
-If the value within brackets is preceded by a ‘+’ sign, add the value to the already existing Armour Piercing value instead (if the model already had Armour Piercing). If not, use the value directly.</description>
-    </rule>
-    <rule id="ab5a-ba3e-e350-f395" name="Bodyguard (X)" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>When a Character is joined to a unit in which at least one model has the Bodyguard special rule, that Character gains Stubborn. When Characters or Character types are stated in brackets, Bodyguard only works for the specified
-Characters or Character types.</description>
-    </rule>
-    <rule id="52c0-872b-e1d3-6cde" name="Born Predator" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>A model part with this special rule may reroll all natural to-hit rolls of ‘1’ in Close Combat.</description>
-    </rule>
-    <rule id="9acb-baeb-7606-3a9e" name="Breath Weapon (X) - Special Attack" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Model parts with this special rule can use it only once during the game. If a model has more than one Breath Weapon, it can only use one Breath Weapon in a single phase. It can be used either as a Special Shooting Attack or as a Special Close Combat Attack.
-
-● As a Special Shooting Attack (normally in the Shooting Phase): Choose a target using the normal rules for Shooting Attacks. The attack has a Range of 6”. This attack can be used even if the model Marched previously in this turn, as well as for a Stand and Shoot Charge Reaction .
-
-● As a Special Close Combat Attack (normally in the Close Combat Phase): The attack is made at the model part&apos;s Initiative. Declare that you are using the Breath Weapon when allocating attacks, and choose a unit in base contact to attack with it.
-
-No matter if it is used as a Shooting or Close Combat Attack, a Breath Weapon causes 2D6 automatic hits on its target .
-The Strength and the special rules (if any) of these hits are given within brackets, such as “Breath Weapon (Strength 4, Flaming Attacks)”.
-When several model parts in the same unit have this special rule, roll for the number of hits separately.</description>
-    </rule>
-    <rule id="8981-1d0f-0196-5872" name="Cannot March" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Units with one or more models with this special rule cannot perform a March Move.</description>
-    </rule>
-    <rule id="988c-b13a-2351-61dd" name="Channel" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Each model part with this special rule adds +1 to its side&apos;s Channel rolls. All Wizards have this special rule.</description>
-    </rule>
-    <rule id="49b1-6bb8-c3af-33f9" name="Cold-Blooded" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>When units with more than half of their models with this special rule take a Leadership Test, roll one additional D6 and remove the highest D6 rolled.</description>
-    </rule>
-    <rule id="eadc-030a-53a2-55b9" name="Combined Strength" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>​Skink Braves may add Caimans to their unit. These Caimans are R&amp;F models of a different Troop Type (Monstrous Infantry). Follow the normal rules for determining if the type of the ​unit​ is considered to be an Infantry or Monstrous Infantry unit (See Troop Types).  Caimans follow the rules for matching bases (see Front Rank), except that they do not have to be placed as far forward as possible, but can be placed anywhere in the unit. Skink Braves and  Caimans in the same unit do not share a common wound pool even though they are both R&amp;F models. Instead each type have their own wound pool (wounds are never passed between the types, any excess wounds are lost) 
-- Distributing Hits: ​When distributing hits (i.e. for attacks towards the unit as a whole) to the unit, first distribute hits between R&amp;F models, champion and/or character(s). Then randomize all hits distributed onto R&amp;F models. Roll a D6 for each hit:​1-4​: a Skink Brave is hit. ​5-6​: a Caiman is hit. 
- 
-- Stomps: ​When distributing hits from Stomps, ignore all models in the unit that are not Infantry. Hits distributed onto Skink Braves are not randomized.  
- 
-- Allocating Attacks: ​In close combat, attacks can be allocated as normal towards different wound pools in base contact; Skink Braves, Caimans, Champion, Character(s).  
- 
-- Swirling Melee: ​Any enemy allocating attacks using the Swirling Melee rule (i.e. attacking Rank-and-File models not in base contact) may choose to do this either against Skink Braves or against Caimans. If this is used to attack Caimans, the attacks suffer a -1 to-hit modifier.</description>
-    </rule>
-    <rule id="13eb-7241-d8bb-7140" name="Crush Attack - Special Attack" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>A model part with this rule can exchange all of its normal Close Combat Attacks for a single Special Attack, which cannot be made as a Supporting Attack, is resolved at Initiative 0, has Strength 10 and Multiple Wounds (Ordnance). Crush Attacks never benefit from any equipment or special rule the model may have (since it is a Special Attack). Even though this is a Special Attack, the attack is Allocated as if it was a normal Close Combat Attack. The model can still make other Special Attacks such as Stomp or Impact Hits.</description>
-    </rule>
-    <rule id="99b7-e92b-3a98-9c03" name="Daemonic Instability" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>When a unit with this Special Rule fails a Break Test, it does not flee from combat. Instead, it suffers a number of Wounds equal to the amount by which the test was failed (Simplified formula: 2D6+CSLd), ignoring the usual minimum 0 for its Leadership Characteristic. These Wounds are distributed following the rules for Unstable, with no saves of any kind allowed. Only characters with Daemonic Instability can join units with Daemonic Instability, and Characters with Daemonic Instability cannot join units without Daemonic Instability. If a model has both Daemonic Instability and Unstable, disregard the latter.</description>
-    </rule>
-    <rule id="54ee-3450-34ff-fd56" name="Devastating Charge" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>In the first round of a combat after a model with this rule has successfully charged into combat, model parts with this special rule have +1 Attack.</description>
-    </rule>
-    <rule id="8051-e889-08ee-08cd" name="Distracting" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Close Combat Attacks allocated at a model with this special rule suffer a 1
-penalty when rolling to hit. This to hit modifier cannot be combined with any other negative to hit modifiers.</description>
-    </rule>
-    <rule id="17a2-06c0-0050-339c" name="Divine Attacks" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Successful Ward Saves taken against attacks with this special rule, or against Close Combat Attacks made by model parts with this special rule must be rerolled.</description>
-    </rule>
-    <rule id="179e-f886-97ad-7ca8" name="Drop Rocks" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>​Sweeping Attack which can be used once per game, the enemy unit suffers D3  Strength 4 hits for each Pteradon in the unit. </description>
-    </rule>
     <rule id="78e2-8d11-019f-895a" name="Emboldening Boughs" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <description>Units with more than half of their models with this special rule have Stubborn while more than half of the unit’s Footprint is within a Forest.</description>
-    </rule>
-    <rule id="1150-f4b2-8993-95e0" name="Engine of the Ancients" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>The model gains Telepathic Link. At the beginning of each friendly Player Turn choose one of the following
-configurations. The effects last until the beginning of the next friendly Player Turn:
-
-- Choose a Magic Path. Friendly Wizards casting spells from this Path have the casting values decreased by 1.
-
-- During the owner’s Shooting Phase, pick an enemy unit that is not Engaged in Close Combat and within 9” of
-the Engine of the Ancients. That unit suffers D3 Metalshifting hits.
-
-- All friendly units within 6” of the Engine of the Ancients gain a Ward Save (5+), which can only be used against
-Ranged Attacks.
-
-The last configuration is active starting from before the battle (after moving Vanguarding units), till the first friendly Player Turn.</description>
-    </rule>
-    <rule id="d0b0-97c2-b9b2-bda5" name="Engineer" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>A model with this special rule allows a War Machine within 3&quot; to use the Engineer&apos;s Ballistic Skill instead of its own and to reroll any rolls on the Misfire Table. (If there are several War Machines within 3&quot; of the Engineer, declare which one will receive the Engineer&apos;s benefits this Player Turn before firing it). If the War Machine uses a Flame Thrower Artillery Weapon, all D3 rolls for the number of hits the Flame Cannon scores on its target may be rerolled.
-If this is used, you must either reroll all dice or none.
-This rule cannot be used by a model that is Engaged in Combat.</description>
-    </rule>
-    <rule id="982e-9d9c-851e-eff5" name="Ethereal" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Models with this special rule treat all Terrain as Open Terrain for movement purposes, but cannot end their
-movement inside (or within 1&quot; of) Impassable Terrain. Model parts with Ethereal gain Magical Attacks, and
-non-mount model parts with Ethereal gain Ward Save (5+), which is increased to Ward Save (3+) against all attacks that are not Magical Attacks. Units including any non-mount R&amp;F part with Ethereal can only be joined by Characters with Ethereal on a non-mount part.</description>
-    </rule>
-    <rule id="f262-31af-7436-6b4d" name="Fast Cavalry" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Models with this special rule have Light Troops and Vanguard. If a unit consisting solely of models with Fast Cavalry voluntarily flees as a Charge Reaction and subsequently rallies the next friendly Player Turn, then the unit may move
-and shoot during that Player Turn. The rallied unit may not charge and counts as having moved for the purpose of shooting. This rule cannot be applied if a unit fails to rally on the next friendly Player or involuntarily flees, such as a result of a failed Panic Test.</description>
-    </rule>
-    <rule id="bbbe-330a-7ca7-3b08" name="Fear" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>All enemy units in base contact with one or more models with this special rule suffer a 1 Leadership modifier. Models that are Immune to Psychology or that have Fear themselves are immune to the effects of Fear. At the start of each
-Combat Round, units in base contact with one or more enemy models with Fear must take a Leadership Test. If this test is failed, the models in the unit have their Weapon Skill reduced to 1 for the remainder of the Combat Round.</description>
     </rule>
     <rule id="0c28-6f4b-765c-238d" name="Fey Arrows" hidden="false">
       <profiles/>
@@ -10063,44 +9959,6 @@ Starlight Shaft:  Magical Attacks, Flaming Attacks, Divine Attacks
 Perforating Tip:  Armour Piercing (3)
 Jewelweed Shot:  Multiple Shots (2)</description>
     </rule>
-    <rule id="f3b2-85dc-a1e1-dd45" name="Fight in Extra Rank" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Models with this special rule can make Supporting Attacks from an additional Rank. (So, normally, this means that models with this special rule will be able to make Supporting Attacks from the 3rd rank). This rule is cumulative, allowing an additional rank to make Supporting Attacks for each instance of this special rule.</description>
-    </rule>
-    <rule id="fa7f-d517-d1e4-9502" name="Fireborn" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Model parts with this special rule have a Ward Save (2+) against Flaming Attacks. While a model has Fireborn, it cannot benefit from Regeneration.</description>
-    </rule>
-    <rule id="1c13-1f10-850a-5c44" name="Flaming Attacks" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>This rule is applied to attacks made with this special rule and attacks from model parts with this special rule (both Close Combat and Shooting Attacks). They don&apos;t normally have any special effect. However, they interact with other rules
-(such as Flammable and Regeneration).</description>
-    </rule>
-    <rule id="6c0b-3f13-524c-1737" name="Flammable" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Attacks with the Flaming Attacks special rule must reroll failed to wound
-rolls against models with this special rule.</description>
-    </rule>
-    <rule id="0424-9d00-5cf6-1c3b" name="Fly (X)" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Units composed entirely of models with this special rule can make Flying Movements when performing a Move Chargers move or in the Remaining Moves subphase.
-When a unit makes a Flying Movement, substitute the models’ Movement Characteristic with the value given in brackets (X). All modifiers to ground movement values are also applied to the flying value of a model. Flying Movement can be used to March. Units using Flying Movement ignore all Terrain and units during the Flying Movement (from their starting to their ending position), but must abide the Unit Spacing rule at the end of the move (unless charging, when the normal exceptions to the Unit Spacing rule apply). They are still affected by the effects of the Terrain from which they take off and in which they land. Models with the Fly special rule also always have Swiftstride and Light Troops.</description>
-    </rule>
     <rule id="4d99-f040-d97b-a104" name="Forest Walker" hidden="false">
       <profiles/>
       <rules/>
@@ -10108,434 +9966,12 @@ When a unit makes a Flying Movement, substitute the models’ Movement Character
       <modifiers/>
       <description>Models with this special rule have Strider (Forest). If a unit comprised entirely of models with this special rule starts the Close Combat Phase with the more than half of its footprint in a Forest, then all model parts with this special rule may reroll to-wound rolls of ‘1’ in Close Combat for the duration of that phase. If the army has one or more models with Channel and Forest Walker within a Forest, add an additional +1 to friendly Channel Attempts.</description>
     </rule>
-    <rule id="351b-4312-9e18-53e8" name="Frenzy" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Model parts with Frenzy have +1 Attack and are Immune to Psychology. After all charges have been declared, each of your units with one or more models (or model parts) with Frenzy must take a Frenzy Test (Leadership Test) if it did not
-declare a charge. If the test is failed, the unit must declare a charge against the closest viable enemy unit, if there is one.
-Characters are never forced to charge out of units. Units with one or more model parts with Frenzy must always pursue and overrun whenever possible. If a model part with Frenzy is ever on the losing side of a Combat Round, it immediately loses this special rule.</description>
-    </rule>
-    <rule id="5c27-b57a-afb2-a5c1" name="Grinding Attacks (X) - Special Attack" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Model parts with this special rule must make a Special Close Combat Attack at their own Initiative against a single enemy unit in base contact. This attack deals a number of hits equal to the value stated within brackets (X). These attacks automatically hit and have a Strength equal to the model&apos;s own Strength. Grinding Attacks never benefit from any equipment or special rule the model may have (since they are Special Attacks). If a model has both Grinding Attacks and Impact Hits, it may only use one of these rules in the same Round of Combat (you may choose which). When several model parts in the same unit have this special rule, and when X is a random number (for example Grinding Attacks(2D3)), roll for the number of hits separately.</description>
-    </rule>
-    <rule id="eb6e-0176-89d0-d671" name="Hard Target" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Shooting Attacks targeting a unit in which more than half of models have this special rule suffer a -1 penalty when rolling to hit.</description>
-    </rule>
-    <rule id="0413-de6f-f6b3-99e0" name="Hatred" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Model parts with this special rule may reroll failed to hit rolls during the first Round of Combat. Sometimes this rule may only work against certain enemies, which are then stated in brackets. For example, “Hatred (Army Book: Empire of Sonnstahl)” means that Hatred only applies when attacking models from the Empire of Sonnstahl Army Book.</description>
-    </rule>
-    <rule id="6338-4d93-cb2b-49aa" name="Hellfire" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>At the end of a phase in which a unit has suffered one or more unsaved Wounds from a model part or an Attack with this rule, the unit suffers an additional D3 Strength 3 hits.</description>
-    </rule>
-    <rule id="7bc5-3e66-b62c-c3f1" name="Hold Your Ground" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>All units within 12&quot; of a friendly non-fleeing model with this special rule may receive the ability to reroll failed
-Leadership Tests.</description>
-    </rule>
-    <rule id="bf92-a7ca-3ba4-9552" name="Immune to Psycology" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>If more than half of a unit&apos;s models are Immune to Psychology, the unit automatically passes Panic Tests and cannot declare a Flee reaction (unless already fleeing). Models that are Immune to Psychology are also immune to the effects of Fear.</description>
-    </rule>
-    <rule id="32d2-a81a-4578-41b1" name="Impact hits (X) - Special Attack" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Model parts with this special rule in base contact with an enemy unit can (and must) make a Special Close Combat Attack in the first Round of Combat after successfully charg ing . Impact Hits are resolved at Initiative 10 and inflict a number of hits equal to the value stated within brackets (X) to the charged enemy unit. Impact Hits automatically hit and have a Strength value equal to the model part &apos;s own Strength, with +1 Strength for every Full Rank after the first in the unit, provided that those ranks are comprised entirely of models with the Impact Hits special rule. Due to being Special Attacks, Impact Hits do not benefit from weapon bonuses or special rules.
-If a model has both Grinding Attacks and Impact Hits, it may only use one of these rule in the same Combat Round (you may choose which). If the value within brackets is preceded by a ‘+’ sign, add the value to the already existing Impact Hits instead (if the model part already had Impact Hits). If not, use the value directly. When several model s in the same unit have this special rule, and when X is a random number (for example Impact Hits(D6)), roll for the number of hits separately.
-In Chariots models , only the Chariot model part itself use this Special Attack. In the other multipart models, only the mount part s can use it.</description>
-    </rule>
-    <rule id="8dab-26ba-334d-b6b7" name="Insignificant" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Units consisting entirely of models with this special rule do not cause Panic Tests on friendly units without this special rule. Only Insignificant Characters can join units with Insignificant R&amp;F models.</description>
-    </rule>
-    <rule id="6f2d-e8cd-9309-6cb9" name="Inspiring Presence" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>All units within 12&quot; of a friendly non-fleeing model with this special rule may receive the ability to use the
-Leadership of the model with Inspiring Presence, instead of their own Leadership. This ability follows all the normal rules for using a Borrowed Characteristic, meaning that effects modifying the Leadership of the model with Inspiring Presence are applied before borrowing the model ’s Leadership. This borrowed Leadership may then be further modified.</description>
-    </rule>
-    <rule id="28c2-8252-7eaf-b3fb" name="Lethal Strike" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>If an Attack with this special rule, or a Close Combat Attack from a model part with this special rule rolls an unmodified &apos;6&apos; to wound, this Wound has Armour Piercing (6) and Regeneration Saves cannot be taken against it.</description>
-    </rule>
-    <rule id="f404-5e25-ddfa-a222" name="Light Troops" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Units composed entirely of models with this special rule are allowed to make any number of Reforms when moving in the Remaining Moves subphase, while they may still Advance or March. They are allowed to shoot even if they Marched or Reformed. No model may move more than its Movement allowance (or twice that number if Marching), from its starting position to its final position, around any obstructions (including the Unit Spacing rule). If a model performed any action during the movement (such as Sweeping attacks), the distance moved is counted from its starting position to the point on the Battlefield where it performed that action and then to its final position.If more than half the models in a unit have the Light Troops special rule, the unit always counts as having 0 Full Ranks. Characters with Light Troops that are joined to units with one or more models without Light Troops, lose this rule for as long as it remains with the unit .</description>
-    </rule>
-    <rule id="a32b-34f5-3ad0-ccb4" name="Lightning Attack" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Units with the Fly special rule that, suffer one or more hits during a single phase from attacks with this special rule, or attacks from model parts with this special rule, suffer an additional D6 Strength 4 hits at the end of that Phase.</description>
-    </rule>
-    <rule id="6dca-0ce0-13f6-b428" name="Lightning Reflexes" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Model parts with this special rule have +1 to hit with their Close Combat Attacks. This does not apply if the model part would be striking at initiative 0 (for example due to a Great Weapon or the Mesmeric Allure spell). If this is the case, it strikes at its own Initiative instead.</description>
-    </rule>
-    <rule id="f6da-4ff4-72af-f5b2" name="Magic Resistance (X)" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>All models in a unit with one or more models with Magic Resistance add the value within brackets (X) to any Ward Save rolls (using the same rules as for adding to Armour Saves) when rolling Ward Saves against Wounds directly caused by
-spell effects. Magic Resistance, like most special rules, is not cumulative. Note that Magic Resistance does not grant Ward Saves for wounds caused indirectly by Spells, such as granting models rules, where this later causes damage.</description>
-    </rule>
-    <rule id="c202-c60b-9af6-6124" name="Magical Attacks" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Attacks with this special rule or Attacks made by model parts with this special rule normally don’t have any special effect. However, they interact with other rules (such as Ethereal). Models with this special rule apply it to all their attacks, including Special Attacks such as Stomp, Impact Hits, and Breath Attacks (unless stated otherwise).All attacks caused by spells and Magical Items have Magical Attacks .</description>
-    </rule>
     <rule id="7400-463a-9500-4db5" name="Master Archers" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <description>Models with this special rule count as being equipped with the following Fey Arrows (see Armoury): Truemark Arrow, Starlight Shaft, Perforating Tip and Jewelweed Shot.</description>
-    </rule>
-    <rule id="4e3e-3206-b1c3-c139" name="Metalshifting" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Attacks with this special rule or Close Combat Attacks made by model parts with this special rule don&apos;t roll to wound as normal. Instead, they always wound on a roll equal to or greater than the target&apos;s Armour Save. An unmodified &apos;6&apos; always wounds and an unmodified &apos;1&apos; always fails to wound. These attacks have Armour Piercing (6) and Flaming Attacks.</description>
-    </rule>
-    <rule id="d766-c60d-2a43-2637" name="Move or Fire" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Shooting Weapons or model parts with this special rule may not shoot if they moved during the current Player Turn.</description>
-    </rule>
-    <rule id="cc69-c792-df5a-0ffa" name="Multiple Shots (X)" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Shooting Weapons or model parts with this special rule may choose to fire multiple times instead of a single time, in each Shooting Phase. How many times they can shoot is stated in brackets. However, using this special rule imposes a -1 to hit modifier on all shots fired. All R&amp;F models in a single unit must use the Multiple Shots rule if at least one of them uses this rule (if possible).</description>
-    </rule>
-    <rule id="1941-6634-0c11-38dd" name="Multiple Wounds (D3)" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Unsaved Wounds caused by attacks with this special rule or by Close Combat Attacks from model parts with this special rule are multiplied into the value given in brackets (X). If the value is a Dice (such as “Multiple Wounds (D3)”), roll one
-such Dice for each unsaved Wound with this special rule. The amount of Wounds that the attack is multiplied into can never be higher than the Wounds Characteristic of the Target (excluding Wounds suffered previously in the battle). For example, if a Multiple Wounds (D6) attack wounds a Troll (W3) and rolls a ‘5&apos; for the amount of Wounds, this is reduced to 3 Wounds.
-
-If (Ordnance) is stated as the value in brackets, this normally counts as Multiple Wounds (D3+1), but against targets with the Fly special rule this is increased to Multiple Wounds (D3+2). Sometimes this rule is connected to certain Troop Types or special rules. If this is the case, the Troop Type will be given within brackets (Y), for example Multiple Wounds (2, Infantry). If this is the case, only apply the Multiple Wounds rule when attacking models of the given Troop Type or possessing the given special rules.</description>
-    </rule>
-    <rule id="cca5-a044-c1f2-2366" name="Multiple Wounds (X)" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Unsaved Wounds caused by attacks with this special rule or by Close Combat Attacks from model parts with this special rule are multiplied into the value given in brackets (X). If the value is a Dice (such as “Multiple Wounds (D3)&quot;), roll one such Dice for each unsaved Wound with this special rule. The amount of Wounds that the attack is multiplied into can never be higher than the Wounds Characteristic of the Target (excluding Wounds suffered previously in the battle). For example, if a Multiple Wounds (D6) attack wounds a Troll (W3) and rolls a ‘5&apos; for the amount of Wounds, this is reduced to 3 Wounds.
-If (Ordnance) is stated after the X value in brackets, an unsaved wound caused by attacks with this special rule to a model with Fly is multiplied into X+1 instead of X.
-Sometimes this rule is connected to certain Troop Types or special rules. If this is the case, the Troop Type will be given within brackets (Y), for example Multiple Wounds (2, Infantry). If this is the case, only apply the Multiple Wounds rule when attacking models of the given Troop Type or possessing the given special rules.</description>
-    </rule>
-    <rule id="59c7-5de5-9ed9-4a85" name="Not a Leader" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Models with this rule can never be the General.</description>
-    </rule>
-    <rule id="defb-3df1-9c6c-4e1e" name="Otherworldly" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Models with this special rule have Magical Attacks, are Immune to Psychology and have a Ward Save (5+). Units with the Otherworldly special rule can only be joined by Otherworldly Characters. Similarly, Otherworldly Characters can only join Otherworldly units.</description>
-    </rule>
-    <rule id="8877-3ad2-6290-4580" name="Pack Leader" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Caimans in the same unit as a Caiman Ancient gain Weapon Skill 4. This effect 
-cannot be combined with the Weapon Skill modifier from a Sun Engine.  </description>
-    </rule>
-    <rule id="963f-6d81-644e-ed95" name="Palanquin" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>When a Cuatl Lord is in a unit with 5 or more models with the Bodyguard special rule, it can be placed anywhere in its unit, it doesn’t have to be placed as far forward as possible. Other models with the Front Rank rule have priority for being as far forward as possible. A model with this special rule can be the General even if it is also the Battle Standard Bearer and it cannot be chosen by the enemy as the model that refuses a Challenge.</description>
-    </rule>
-    <rule id="e0d6-9cda-065f-487a" name="Parry" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Close Combat Attacks from opponents in the front of a model with Parry can never score successful hits on to-hit rolls of better than 4+. This is not considered a to-hit modifier. Apply this before applying any to-hit modifiers.</description>
-    </rule>
-    <rule id="a0ed-5bb0-2145-6e1f" name="Pathmaster" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Wizards with this special rule do not randomly select spells as usual. Instead, they can freely choose their spells from their Path, or if there is a Path stated in brackets, they must use this Path. </description>
-    </rule>
-    <rule id="9fa3-e678-b890-af93" name="Penetrating" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>When a weapon with this special rule hits, check in which arc of the target the shooter is in. The weapon causes a number of hits equal to the number of ranks of its target if the shooter is in the front or the rear arc, or a number hits equal to the number of files of its target if the shooter is in either flank arc. In either case, the number of hits cannot exceed 5.
-Some Penetrating attacks have a higher Strength and/or additional special rules stated in square brackets (such as Strength 3[6], [Multiple Wounds (D3)]). If so, a single hit from this attack uses the Strength value and special rules in brackets. The Bracketed values and special rules are not applied to any other hits.</description>
-    </rule>
-    <rule id="257e-4d91-0df6-fb41" name="Poisoned Attacks" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>If an attack with this special rule, or an attack from a model part with this special rule (both Shooting and Close Combat Attacks), rolls a successful hit with a tohit
-roll of an unmodified &apos;6&apos;, this hit automatically wounds with no to wound roll needed. Shooting Attacks that need a 7+ to hit (or more) can never benefit from Poisoned Attacks. If the Attack can be turned into more than one hit (such as for a hit with Penetrating or Area Attack), only a single hit (of attacker’s choice)
-automatically wounds, all other hits must roll to wound as normal.</description>
-    </rule>
-    <rule id="2b7d-05ce-9b42-e368" name="Poisoned Attacks (Close combat only)" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="e170-bafe-0e6e-3fb0" name="Predatory Roar" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>One use only. Activate this at the start of any Close Combat Phase. When activated 
-choose one friendly unit within 12” of the Stygiosaur. All model parts with Born Predator gain Hatred for the duration of the phase. </description>
-    </rule>
-    <rule id="6bf8-03ac-8887-8310" name="Prey Scent" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>​Before the battle, if you have one or more units of Rhamphodon Riders or a Skink Captain on an Alpha Rhamphodon, you may mark 2 of the enemy’s units with a counter. When attacking a marked unit, Rhamphodons (not their riders) may reroll to hit and gain an additional D3 attacks/model, which must be allocated towards a  marked unit.  </description>
-    </rule>
-    <rule id="9535-626b-cc91-eb1d" name="Quick to Fire" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Shooting Weapons with this special rule or Shooting Attacks from model parts with this special rule don&apos;t suffer the 1 penalty for Moving and Shooting and can make a Stand and Shoot Charge Reaction regardless of the distance to the charging unit.</description>
-    </rule>
-    <rule id="14f8-05d6-2dde-378d" name="Random Attacks (X)" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>A model part with this rule has a random number of Attacks equal to the value between brackets (before adding possible modifier to it). For example, a model with Random Attacks (D3+2) can have between 3 and 5 Attacks. These attacks ignore the limit which states that a model may have a maximum of 10 attacks.</description>
-    </rule>
-    <rule id="933a-756c-5d92-2e36" name="Random Movement (X)" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Units with this special rule cannot Declare Charges and cannot move in the Remaining Moves subphase (which also means they cannot perform Magical Moves). Instead, they move in the Compulsory Moves subphase. Models with this special rule lose Swiftstride (and can never gain it), but always Charge, Flee, Pursue and Overrun the distance stated in brackets.
-
-During the Compulsory Moves subphase, units with this special rule move using the rules for pursuing units, except that they can freely choose which direction to rotate towards before rolling the Pursuit distance, cannot move off the
-Board Edge and only take Dangerous Terrain tests if they actually charge an enemy unit (they still test as normal when fleeing, pursuing a broken enemy or Overrunning).
-
-Characters with Random Movement can only join units with the same special rule (by moving into contact with them during the Compulsory Moves subphase), and units with this rule can only be joined by Random Movement Characters. If a unit has several sets of Random Movement, use the lowest one.</description>
-    </rule>
-    <rule id="9a66-8ccf-2957-b461" name="Regeneration (X)" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Regeneration is a special save, taken after a failed Armour Save. The value of the save will be stated in brackets. Regeneration Saves cannot be taken alongside Ward Saves (if a model has both, it must choose which one to use) and cannot be taken against Flaming Attacks or Lethal Strike blows that rolled &apos;6&apos; to wound . While a model has Fireborn, it cannot benefit from Regeneration.</description>
-    </rule>
-    <rule id="695f-c4db-31a4-b16e" name="Reload!" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Shooting Weapons with this special rule or Shooting Attacks from model parts with this special rule can never Stand and Shoot as a Charge Reaction.</description>
-    </rule>
-    <rule id="7c98-28d5-6c20-062b" name="Requires Two Hands" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>A model wielding a Weapon with this special rule cannot simultaneously use a Shield.</description>
-    </rule>
-    <rule id="fbc9-6558-a0ab-3ae6" name="Scoring" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Units with at least one model with the Scoring special rule are considered Scoring Units and are used for capturing Secondary Objectives. Every army needs a few Scoring units to be able to complete Secondary Objectives, which is why units with the Scoring special rule are marked in the Armybooks with a special pennant icon:
-
-The Scoring special rule can be lost during the game:
-● One or more models in the unit are Light Troops.
-● A unit that is Fleeing loses its Scoring special rule for as long as it if Fleeing.
-● An Ambushing unit that entered the Battlefield on Game Turn 4 or later loses its Scoring Special rule.
-● A unit that has performed a Post-Combat Reform loses its Scoring special rule until the end of the current
-Player Turn.</description>
-    </rule>
-    <rule id="5d00-a3cf-3558-9c90" name="Scout" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Before deploying an army that includes units with Scout, you must state which of your units with this special rule will use it, starting with the player that picked the Deployment Zone. Deploy your army as usual, but without deploying any of the Scouting units. These units are placed after all other non Scouting units have been deployed. They can either be deployed in your Deployment Zone, using the normal rules, or they can be deployed outside the Deployment Zone, but must be more than 18” away from any enemy units . This is decreased to 12” if the Scouting unit is deployed whole within a Forest, Ruin, Building, Field or Water Terrain Feature . Scouting units that are deployed outside their player’s Deployment Zone may not Declare Charges in the first Player Turn (if their side has the first turn). If both players have Scouting units, alternate deploying one unit at a time, starting with the player that finished deploying first .</description>
-    </rule>
-    <rule id="c466-e9cf-7ab5-b0e6" name="Sharp Horns" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>The model may reroll the dice for number of impact hits.</description>
-    </rule>
-    <rule id="f49f-77d8-68e0-1be6" name="Skink Palanquin" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description> A model with this special rule loses  the Front Rank rule when it is in a unit of Saurian Warriors or Skink Braves that does not contain any Caiman model. </description>
-    </rule>
-    <rule id="9f78-9e64-5f78-9116" name="Skirmishers" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Models with this special rule always gain Light Troops. Shooting at Skirmishers suffers a -1 to-hit modifier.
-Skirmishing models are not placed in base to base contact with each other. Instead, models are placed with a 12.5mm distance between them. This gap is considered part of the unit for Line of Sight purposes, and will have the same Height as the largest fraction of the models in the unit. Other than this gap between models, units of Skirmishers follow the normal rules for forming units and therefore have a front, two flanks, a rear, can perform Supporting Attacks from the second rank, and so on . Skirmishing units can only be joined by Characters that have the same Troop Type as the unit. A Character which joins a unit of Skirmishers gains Skirmishers for as long as it remains with the unit. The unit ceases to be Skirmishers if all models with Skirmishers are wiped out, immediately contracting their loose formation into a normal formation, without moving the centre of the front rank. Nudge any unit as normal to maintain base contact when possible . The Character is always considered Mismatched for the purpose of placement within the unit unless it has the exact same base size as the other Skirmisher models.</description>
-    </rule>
-    <rule id="8ef5-0239-8db2-5052" name="Stomp (X) - Special Attack" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>A model with this special rule must make a Special Close Combat Attack in the Close Combat Phase at Initiative 0 against a single enemy unit in base contact, provided that the Troop Type of the target unit is Infantry, War Beast, Swarm or
-War Machine . This attack deals a number of hits equal to the value stated within brackets (X), which automatically hit and have a Strength equal to the model&apos;s own Strength. Hits caused by Stomp can only be allocated onto models with Infantry, War Beast, Swarm or War Machine Troop Type (ignore models of different Troop Type when distributing hits).
-When several models in the same unit have this special rule, and when X is a random number (for example Stomp (D6)), roll for the number of hits separately.
-
-In multipart models, riders can never Stomp. Stomp attacks can only ever be allocated to models that can normally be stomped. Being a Special Attack, Stomp never benefits from any equipment or special rule the model has.</description>
-    </rule>
-    <rule id="0603-04a0-1dae-2c25" name="Strider (Forest)" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Models with this special rule automatically passes Dangerous Terrain tests taken due to Terrain, cannot be prevented from Marching by the Terrain and never lose their Steadfast or Rank Bonus due to the Terrain . Sometimes this special rule is only linked to a specific type of Terrain, stated in brackets. In this case, the Strider rule effect is only applied in relation to the specified Terrain type.</description>
-    </rule>
-    <rule id="b5eb-c2ee-5c02-c7a6" name="Strider (X)" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Models with this special rule automatically passes Dangerous Terrain tests taken due to Terrain, cannot be prevented from Marching by the Terrain and never lose their Steadfast or Rank Bonus due to the Terrain . Sometimes this special rule is only linked to a specific type of Terrain, stated in brackets. In this case, the Strider rule effect is only applied in relation to the specified Terrain type.</description>
-    </rule>
-    <rule id="f877-7c70-71da-b29f" name="Stubborn" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>A unit with at least one model with this special rule ignores any Combat Score penalties to its Leadership when taking Break Tests or Combat Reform Leadership Tests.</description>
-    </rule>
-    <rule id="e96e-5a42-8f9b-4e6a" name="Stupidity" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>At the start of a Player Turn, each of the Active Player’s unengaged nonfleeing
-units with one or more models (or a part of them) with this special rule must take a Leadership Test. If the test is failed, the unit must move D6” directly forward
-(stopping 1” before Impassible Terrain or other units) in the Compulsory Moves subphase and may not perform any other voluntary actions this Player Turn (such as charging, moving, shooting, casting spells and so on). If the model has no front (i.e. the model is on a round base), randomize which direction to move in. All models with the Stupidity special rule are also Immune to Psychology.</description>
-    </rule>
-    <rule id="00c3-c931-0445-2efa" name="Sweeping Attack - Special Attack" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Special Ranged Attack. This attack may be used by units consisting of models with this special rule. At the end of the Remaining Moves subphase (or the Magic Phase if this is done as part of a Magical Move), nominate one unengaged enemy unit which the unit Advanced or Marched through this phase (Bases are Overlapping, even partially). The whole unit makes an attack against the chosen enemy unit ( follow the description in the unit profile). These attacks hit automatically. When a model performs a Sweeping attack, the distance moved is counted from its starting position to the point on the Battlefield where it performed the attack, and then to its final position.</description>
-    </rule>
-    <rule id="97a7-b378-d33c-b598" name="Swiftstride" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>When a unit composed entirely of models with this special rule rolls Charge Range, Flee Distance, Pursuit Distance or Overrun Distance, it rolls an additional D6 (normally this will lead to rolling 3D6) and discards the lowest dice.</description>
-    </rule>
-    <rule id="fbf2-8caa-49bd-687e" name="Telepathic Link" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>A Cuatl Lord may cast spells of type “Damage” through a model with this special rule if it is within 24” of the Cuatl Lord. When casting through the Telepathic Link, measure the Range for the spell from the Telepathic Link and use its Front Arc and Line of Sight. The Range of the spell is reduced by half. The Cuatl Lord may cast spells of type “Missile”, even if it is Engaged in Combat, as long as the Telepathic Link is not. If the spell is miscast, the Cuatl Lord rolls on the Miscast Table as normal and the Telepathic Link suffers a Strength PDU+1 hit. If the Cuatl Lord casts a spell through a Telepathic Link, the attribute gets cast through it as well (measure Range and use Front Arc and Line of Sight from the Telepathic Link ). The “caster” is still considered to be Cuatl Lord.</description>
-    </rule>
-    <rule id="4933-2a68-627e-5e54" name="Terror" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>When a unit with one or more models with this special rule declares a Charge, its target must take a Panic Test. If the test is failed, the target of the Charge must declare a Flee reaction, if able to do so. All models with Terror also have the
-Fear special rule and are immune to Fear and Terror.</description>
-    </rule>
-    <rule id="9963-0573-a9aa-83d7" name="Thunderous Charge" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>In the first round of a combat after a model with this rule has successfully charged, model parts with this special rule receive a +1 Strength bonus to their normal Close Combat Attacks. This Strength bonus can only be used for Attacks
-directed against the charged enemies.</description>
-    </rule>
-    <rule id="7255-67f2-6790-a658" name="Towering Presence" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>A model with Towering Presence is of Gigantic Height and can never be joined or join a unit (unless it is a War Platform). A model with Towering Presence increases its Hold Your Ground or Inspiring Presence Range by 6&quot;.</description>
-    </rule>
-    <rule id="3ae4-5679-37d5-8372" name="Toxic Attacks" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Attacks with this special rule or Close Combat Attacks made by model parts with this special rule are always Strength 3 and Armour Piercing (6).</description>
     </rule>
     <rule id="1887-82a6-d3f1-f661" name="Tree Singing" hidden="false">
       <profiles/>
@@ -10545,112 +9981,7 @@ directed against the charged enemies.</description>
       <description>Bound Spell Power Level 3, Range 24&quot;, Duration: Instant. This spell targets a single Forest and affects any friendly unit completely inside the Forest and all enemy units in contact with the Forest. Enemy units suffer D6 Strength 5 hits. The
 target Forest and all eligible friendly units (but not the enemy units) are moved D3+3&quot; in a single direction, chosen by the caster before rolling for the distance, following the rules for Magical Move. The Forest immediately stops just before moving into contact with enemy units or other Terrain Features.</description>
     </rule>
-    <rule id="1988-6ffe-3ed2-edec" name="Unbreakable" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Units with this special rule are Immune to Psychology and automatically pass all Break Tests. Characters with the Unbreakable special rule can only join Unbreakable units. Unbreakable units can only be joined by Unbreakable
-Characters.</description>
-    </rule>
-    <rule id="d911-e8a2-e585-96ee" name="Undead" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Units with this special rule gain Unstable and Immune to Psychology. Undead units cannot March, unless they start their move within the range of a friendly model’s Inspiring Presence . The only Charge Reaction an Undead unit can make is Hold.</description>
-    </rule>
-    <rule id="1af8-f44b-3e14-b3c4" name="Unstable" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Unstable units can only be joined by Unstable Characters.
-Units with this special rule automatically pass all Break Tests. When a unit with this special rule loses a combat, it suffers a Wound (without any saves allowed) for each point of Combat Score by which it lost the combat.
-
-The number of lost wounds is reduced in some situations. Apply the modifiers in the following order:
-1. If the unit is Stubborn , halve the number of lost wounds (round fractions up).
-2. If the unit is Steadfast , reduce all lost wounds above 12 to 12.
-3. If the unit receives Hold Your Ground, reduce the number of lost wounds with the unit’s current Rank Bonus. Units with no Rank Bonus reduce the number of wounds lost by 1 instead.
-Apply all other modifiers (from items/special rules/spells etc) afterward.
-
-The Wounds are distributed in the following order:
-1. R&amp;F models (excluding Champions)
-2. Champion
-3. Characters (distributed by the owner of the unit, as evenly as possible)</description>
-    </rule>
-    <rule id="973c-98e0-03a8-11e8" name="Unweildy" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Shooting Weapons with this special rule or Shooting Attacks from model parts with this special rule suffer an additional -1 to hit (for a total of 2) for Moving and Shooting. If combined with Quick to Fire, the model can only ignore the normal
--1 to hit from Moving and Shooting, not the additional -1 to hit from this rule..</description>
-    </rule>
-    <rule id="30f2-dc53-796a-a1b9" name="Vanguard" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>After Deployment (including Scouts), units composed entirely of models with this special rule may perform a 12&quot; move. The move is performed as if in the Remaining Moves subphase, including any actions and restrictions the unit would
-normally have in the Remaining Moves subphase (such as Wheeling, Reforming, joining units, leaving units and so on).
-The 12&quot; distance is used instead of the unit&apos;s Movement Characteristic and no March Moves are allowed. This move cannot be used to move within 12&quot; of enemy units. This is decreased to 6” for enemy units which have either Scouted or
-Vanguarded. Units that have moved in this way may not Declare Charges in the first Player Turn (if their side has the first turn). If both players have units with Vanguard, alternate moving units one at a time, starting with the player that
-finished deploying last. Instead of moving a unit, a player may declare to not move any more Vangarding units.</description>
-    </rule>
-    <rule id="05e2-7ef6-5bd9-30b0" name="Venomous Tide" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description> ​If an enemy unit is in base contact with a model with this rule, all attacks made against that unit gain Poisoned Attacks. </description>
-    </rule>
-    <rule id="fa55-e475-548c-843d" name="Volley Fire" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Shooting Weapons with this special rule or Shooting Attacks from model parts with this special rule ignore intervening models for Cover purposes when shooting. (However, they don&apos;t ignore Terrain and must still be able to draw a Line of
-Sight to their target). Furthermore, (unless making a Stand and Shoot Charge Reaction) if the unit hasn&apos;t moved in this Player Turn, all models with a Volley Fire Shooting Weapon may shoot (even if they are further back than the usual first
-two ranks allowed to shoot).</description>
-    </rule>
-    <rule id="15dd-461c-e999-a1a9" name="War Platform" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Models with this special rule may join units as if they were Characters, even if they are not Characters and even if they are Large Targets, and follow the rules for Characters with regards to distributing hits. While joined to and moving with a unit consisting of 5 or more models (besides the War Platform itself) a model with the War Platform special rule may March even though its Troop Type would normally forbid it, for example if it is a Chariot. When joined to a unit, it must always be placed in the centre of the front rank, possibly pushing back models with the Front Rank rule, and must keep its position in the centre of the front rank at all times. If two positions are equally central (this is the case in a unit with an even number of models in the first rank), the War Platform can be placed in either of these positions. If the War Plattform cannot be placed in the centre of the the front rank (for example due to Mismatching bases or the front rank being too narrow), the model cannot join the unit. This means that a War Platform can never join a unit with Mismatching bases and that only a single War Platform can ever be in the same unit. Models with this rule lose Swiftstride.</description>
-    </rule>
-    <rule id="d970-41c1-7931-dd2c" name="Ward Save (X)" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Ward Saves are special saves, taken after failed Armour Saves. The value of the save will be stated in brackets. Ward Saves cannot be taken alongside Regeneration Saves (if a model has both, it must choose which one to use).</description>
-    </rule>
-    <rule id="7fa0-0d36-4ee3-87f7" name="Weapon Master" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>At the beginning of each Round of Combat, model parts with this special rule may choose which weapon they fight with. This includes selecting to use a Hand Weapon even if they have other weapons. If armed with a Magical Weapon, the
-model must still use it.</description>
-    </rule>
     <rule id="a5a1-8b78-0ca6-7be8" name="Wizard Apprentice with 1 learned spell" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="dfe4-4598-cdcb-3d58" name="Wizard Conclave (Spells)" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>The Champion of a unit with the Wizard Conclave special rule gains +1 Wound in addition to the normal
-Characteristics increases associated with being a Champion and is a Wizard Apprentice. This Champion knows predetermined spells, defined in the Armybook. A Wizard Conclave Champion will also know all Trait Spells and Attribute Spells from Paths which its predetermined spells are taken from.</description>
-    </rule>
-    <rule id="29e8-b44d-3c2c-3068" name="Wizard Conclave (Swarm of Insects, Awaken the Beast. Shamanism)" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -10664,65 +9995,6 @@ Characteristics increases associated with being a Champion and is a Wizard Appre
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="dd92-91d5-9639-454b" name="Barding" hidden="false" profileTypeId="41726d6f757223232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Saving Throw modifier" characteristicTypeId="536176696e67205468726f77206d6f64696669657223232344415441232323" value="6+"/>
-        <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323" value="-1 Movement"/>
-        <characteristic name="Type" characteristicTypeId="94cf20a4-1493-f0f7-cc00-c1a4c796e7cd"/>
-      </characteristics>
-    </profile>
-    <profile id="16b6-183c-4456-5eda" name="Blowpipe" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="3"/>
-        <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323" value="Multiple shots [2], Poisoned Attacks, +1 to hit against units consisting entirely of Towering Presence."/>
-        <characteristic name="Type" characteristicTypeId="29462612-b0ed-72ab-53b7-0db0a426202a" value="Shooting Weapon"/>
-      </characteristics>
-    </profile>
-    <profile id="c1b5-0199-00f3-e5b3" name="Bow" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="18&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="3"/>
-        <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323" value="Volley Fire"/>
-        <characteristic name="Type" characteristicTypeId="29462612-b0ed-72ab-53b7-0db0a426202a" value="Bow"/>
-      </characteristics>
-    </profile>
-    <profile id="a268-59fd-900a-b21f" name="Brace of Pistols" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
-        <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323" value="Quick to Fire, Armout Piercing (1), Multiple Shots (2), Counts as Paired Weapons in Close Combat"/>
-        <characteristic name="Type" characteristicTypeId="29462612-b0ed-72ab-53b7-0db0a426202a"/>
-      </characteristics>
-    </profile>
-    <profile id="a1be-568e-3e16-8a02" name="Crossbow" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="30&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
-        <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323" value="Unwieldy"/>
-        <characteristic name="Type" characteristicTypeId="29462612-b0ed-72ab-53b7-0db0a426202a"/>
-      </characteristics>
-    </profile>
     <profile id="7c35-5318-0791-9993" name="Elven Cloak" hidden="false" profileTypeId="41726d6f757223232344415441232323">
       <profiles/>
       <rules/>
@@ -10732,42 +10004,6 @@ Characteristics increases associated with being a Champion and is a Wizard Appre
         <characteristic name="Saving Throw modifier" characteristicTypeId="536176696e67205468726f77206d6f64696669657223232344415441232323" value="6+"/>
         <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323" value="If combined with Light Armour the wearer gains Innate Defence (6+)"/>
         <characteristic name="Type" characteristicTypeId="94cf20a4-1493-f0f7-cc00-c1a4c796e7cd" value="None"/>
-      </characteristics>
-    </profile>
-    <profile id="6848-ffbd-fbfb-8d08" name="Flail" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Melee"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="+2"/>
-        <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323" value="Close Combat Attacks allocated at a model wielding a Flail have a +1 bonus when rolling to hit . Requires Two Hands"/>
-        <characteristic name="Type" characteristicTypeId="29462612-b0ed-72ab-53b7-0db0a426202a"/>
-      </characteristics>
-    </profile>
-    <profile id="2255-1ade-3597-9422" name="Giant Blowpipes" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="3"/>
-        <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323" value="Quick to Fire, Poisoned Attacks"/>
-        <characteristic name="Type" characteristicTypeId="29462612-b0ed-72ab-53b7-0db0a426202a" value="Volley Gun (8)"/>
-      </characteristics>
-    </profile>
-    <profile id="e98c-e9ae-1b64-993c" name="Giant Bow" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="3[5]"/>
-        <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323" value="Multiple Wounds (D3), Armour Piercing (6), Quick to Fire"/>
-        <characteristic name="Type" characteristicTypeId="29462612-b0ed-72ab-53b7-0db0a426202a" value="Bolt Thrower Artillery Weapon"/>
       </characteristics>
     </profile>
     <profile id="8cfc-065a-fc0e-2fd0" name="Great Weapon" hidden="false" profileTypeId="576561706f6e23232344415441232323">
@@ -10806,18 +10042,6 @@ Characteristics increases associated with being a Champion and is a Wizard Appre
         <characteristic name="Type" characteristicTypeId="29462612-b0ed-72ab-53b7-0db0a426202a"/>
       </characteristics>
     </profile>
-    <profile id="74d1-705b-7d2e-6612" name="Handgun" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="24&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
-        <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323" value="Unwieldy, Armour Piercing (1)"/>
-        <characteristic name="Type" characteristicTypeId="29462612-b0ed-72ab-53b7-0db0a426202a"/>
-      </characteristics>
-    </profile>
     <profile id="13bd-4787-a630-c2ea" name="Heavy Armour" hidden="false" profileTypeId="41726d6f757223232344415441232323">
       <profiles/>
       <rules/>
@@ -10839,17 +10063,6 @@ Characteristics increases associated with being a Champion and is a Wizard Appre
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4 (5 if its target is in contact with a forest)"/>
         <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323" value="Multiple Shots (D6+1), Quick to Fire, May March and Shoot, ignores to-hit modifiers from cover"/>
         <characteristic name="Type" characteristicTypeId="29462612-b0ed-72ab-53b7-0db0a426202a" value="Shooting Weapon"/>
-      </characteristics>
-    </profile>
-    <profile id="3b3e-cf6e-3a20-43d6" name="Innate Defence (2+)" hidden="false" profileTypeId="41726d6f757223232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Saving Throw modifier" characteristicTypeId="536176696e67205468726f77206d6f64696669657223232344415441232323" value="2+"/>
-        <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323"/>
-        <characteristic name="Type" characteristicTypeId="94cf20a4-1493-f0f7-cc00-c1a4c796e7cd" value="None"/>
       </characteristics>
     </profile>
     <profile id="639d-65ec-bf0c-57ba" name="Innate Defence (3+)" hidden="false" profileTypeId="41726d6f757223232344415441232323">
@@ -10920,7 +10133,7 @@ Characteristics increases associated with being a Champion and is a Wizard Appre
         <characteristic name="Type" characteristicTypeId="29462612-b0ed-72ab-53b7-0db0a426202a"/>
       </characteristics>
     </profile>
-    <profile id="bec0-23d0-2d01-93b8" name="Lance" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+    <profile id="bec0-23d0-2d01-93b8" name="Light Lance" hidden="false" profileTypeId="576561706f6e23232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -10989,29 +10202,6 @@ Characteristics increases associated with being a Champion and is a Wizard Appre
         <characteristic name="Type" characteristicTypeId="29462612-b0ed-72ab-53b7-0db0a426202a"/>
       </characteristics>
     </profile>
-    <profile id="56a9-268b-822d-0427" name="Pistol" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
-        <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323" value="Quick to Fire, Armnour Piercing (1), Counts as Paired Weapons in Close Combat"/>
-        <characteristic name="Type" characteristicTypeId="29462612-b0ed-72ab-53b7-0db0a426202a"/>
-      </characteristics>
-    </profile>
-    <profile id="3699-2a2c-21e7-70ab" name="Plate Armour" hidden="false" profileTypeId="41726d6f757223232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Saving Throw modifier" characteristicTypeId="536176696e67205468726f77206d6f64696669657223232344415441232323" value="4+"/>
-        <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323"/>
-        <characteristic name="Type" characteristicTypeId="94cf20a4-1493-f0f7-cc00-c1a4c796e7cd" value="Plate Armour"/>
-      </characteristics>
-    </profile>
     <profile id="6fc1-cc27-c2c6-84e9" name="Poisoned Javelin" hidden="false" profileTypeId="576561706f6e23232344415441232323">
       <profiles/>
       <rules/>
@@ -11022,29 +10212,6 @@ Characteristics increases associated with being a Champion and is a Wizard Appre
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="As User"/>
         <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323" value="Quick to Fire, Poisoned Attacks"/>
         <characteristic name="Type" characteristicTypeId="29462612-b0ed-72ab-53b7-0db0a426202a" value="Shooting Weapon"/>
-      </characteristics>
-    </profile>
-    <profile id="b76b-63a3-28e3-85c3" name="Raptor" hidden="false" profileTypeId="4d6f64656c23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="M" characteristicTypeId="4d23232344415441232323" value="7"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="3"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="-"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="4"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="4"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="2"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="2"/>
-        <characteristic name="ArmourSave" characteristicTypeId="41726d6f75725361766523232344415441232323"/>
-        <characteristic name="WardSave" characteristicTypeId="576172645361766523232344415441232323"/>
-        <characteristic name="MR" characteristicTypeId="4d5223232344415441232323"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Cavalry"/>
-        <characteristic name="Base Size" characteristicTypeId="b268-8d89-a887-0d3b" value="25x50mm"/>
-        <characteristic name="Evoked" characteristicTypeId="2f85-d560-70d4-3b71"/>
       </characteristics>
     </profile>
     <profile id="7ca5-586a-9320-e3c9" name="Shield" hidden="false" profileTypeId="41726d6f757223232344415441232323">
@@ -11092,18 +10259,6 @@ Characteristics increases associated with being a Champion and is a Wizard Appre
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="+1"/>
         <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323" value="Armour Piercing (1)"/>
         <characteristic name="Type" characteristicTypeId="29462612-b0ed-72ab-53b7-0db0a426202a" value="Light Lance"/>
-      </characteristics>
-    </profile>
-    <profile id="43b7-6b76-7550-2686" name="Throwing Weapons" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="As User"/>
-        <characteristic name="Special Rules" characteristicTypeId="5370656369616c2052756c657323232344415441232323" value="Quick to Fire, Multiple Shots (2)"/>
-        <characteristic name="Type" characteristicTypeId="29462612-b0ed-72ab-53b7-0db0a426202a"/>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
… shared rules instead

Add some name modifiers to rules like Strider, Armour piercing, Fly to indicate the value; Fly (7) on a dragon for example
Add Armour piercing (1) to Forest Rangers